### PR TITLE
Make imports explicit, add modules to top level

### DIFF
--- a/src/cvi/__init__.py
+++ b/src/cvi/__init__.py
@@ -3,3 +3,13 @@ cvi - A Python library for both incremental and batch cluster validity indices.
 """
 
 __version__ = "0.1.0-alpha.1"
+
+from .modules import (
+    CVI,
+    CH,
+)
+
+__all__ = [
+    "CVI",
+    "CH",
+]

--- a/src/cvi/modules/CH.py
+++ b/src/cvi/modules/CH.py
@@ -9,10 +9,11 @@ import logging as lg
 import numpy as np
 
 # Local imports
-from .common import *
+from . import _base
+
 
 # CH object definition
-class CH(CVI):
+class CH(_base.CVI):
     """
     The stateful information of the Calinski-Harabasz (CH) Cluster Validity Index.
 
@@ -33,7 +34,7 @@ class CH(CVI):
 
         return
 
-    @add_docs(param_inc_doc)
+    @_base.add_docs(_base.param_inc_doc)
     def param_inc(self, sample:np.ndarray, label:int) -> None:
         """
         Incremental parameter update for the Calinski-Harabasz (CH) CVI.
@@ -90,7 +91,7 @@ class CH(CVI):
 
         return
 
-    @add_docs(param_batch)
+    @_base.add_docs(_base.param_batch_doc)
     def param_batch(self, data:np.ndarray, labels:np.ndarray) -> None:
         """
         Batch parameter update for the Calinski-Harabasz (CH) CVI.

--- a/src/cvi/modules/__init__.py
+++ b/src/cvi/modules/__init__.py
@@ -1,6 +1,22 @@
 """
-
+The :mod:`modules` gathers all CVI implementations.
 """
 
-from .common import *
-from .CH import *
+from ._base import (
+    LabelMap,
+    CVI,
+    add_docs,
+    param_inc_doc,
+    param_batch_doc,
+)
+
+from .CH import CH
+
+__all__ = [
+    "LabelMap",
+    "CVI",
+    "add_docs",
+    "param_inc_doc",
+    "param_batch_doc",
+    "CH",
+]

--- a/src/cvi/modules/_base.py
+++ b/src/cvi/modules/_base.py
@@ -127,7 +127,7 @@ def param_inc_doc() -> None:
     pass
 
 # This function documents the shared API for batch parameter updates
-def param_batch() -> None:
+def param_batch_doc() -> None:
     """
     Parameters
     ----------

--- a/tests/test_cvi.py
+++ b/tests/test_cvi.py
@@ -14,23 +14,28 @@ import logging as lg
 from dataclasses import dataclass
 from typing import List, Dict
 
+
 # --------------------------------------------------------------------------- #
 # CUSTOM IMPORTS
 # --------------------------------------------------------------------------- #
+
 
 import pytest
 import numpy as np
 import pandas as pd
 
+
 # --------------------------------------------------------------------------- #
 # LOCAL IMPORTS
 # --------------------------------------------------------------------------- #
 
+
 import src.cvi as cvi
 # TODO: this is a hack; refactor modules so that this is at the top
-from src.cvi.modules.common import CVI
+# from src.cvi import CVI
 
 print(f"\nTesting path is: {os.getcwd()}")
+
 
 # --------------------------------------------------------------------------- #
 # DATACLASSES
@@ -123,13 +128,13 @@ def data() -> TestData:
 # --------------------------------------------------------------------------- #
 
 
-def get_cvis() -> List[CVI]:
+def get_cvis() -> List[cvi.CVI]:
     """
     Returns a list of constructed CVI modules.
     """
 
     cvis = [
-        cvi.modules.CH(),
+        cvi.CH(),
     ]
 
     return cvis


### PR DESCRIPTION
This PR adds `__all__` statements and specifies what names are imported and where.