### PR TITLE
Add .coveragerc, modify abstract pass

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    # Exclude abstract methods raising the not implemented error
+    raise NotImplementedError

--- a/src/cvi/modules/_base.py
+++ b/src/cvi/modules/_base.py
@@ -101,15 +101,15 @@ class CVI():
 
     @abstractmethod
     def param_inc(self, sample: np.ndarray, label: int):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def param_batch(self, data: np.ndarray, labels: np.ndarray):
-        pass
+        raise NotImplementedError
 
     @abstractmethod
     def evaluate(self):
-        pass
+        raise NotImplementedError
 
     def get_cvi(self, data: np.ndarray, label: Union[int, np.ndarray]) -> float:
         """


### PR DESCRIPTION
Fixes #38, improving coverage by adding a .coveragerc and changing abstract methods to raise NotImplementedError.