### PR TITLE
Add numpy dep to docs build requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+numpy


### PR DESCRIPTION
This PR (hopefully) fixes an issue with docs build requirements on readthedocs.